### PR TITLE
Bugfix - Messages with Null Properties

### DIFF
--- a/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
+++ b/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
@@ -117,17 +117,17 @@ namespace ServiceBusEmulator.RabbitMq
 
             if (rMessage.ApplicationProperties != null)
             {
-                foreach (KeyValuePair<object, object> p in rMessage.ApplicationProperties.Map)
+                foreach (KeyValuePair<object, object?> p in rMessage.ApplicationProperties.Map)
                 {
-                    prop.Headers[$"x-sb-app-{p.Key}"] = p.Value.ToString();
+                    prop.Headers[$"x-sb-app-{p.Key}"] = p.Value?.ToString();
                 }
             }
 
             if (rMessage.MessageAnnotations != null)
             {
-                foreach (KeyValuePair<object, object> p in rMessage.MessageAnnotations.Map)
+                foreach (KeyValuePair<object, object?> p in rMessage.MessageAnnotations.Map)
                 {
-                    prop.Headers[$"x-sb-annotation-{p.Key}"] = p.Value.ToString();
+                    prop.Headers[$"x-sb-annotation-{p.Key}"] = p.Value?.ToString();
                 }
             }
 


### PR DESCRIPTION
Fixing a bug with RabbitMQ backend and Messages with null properties.

Fixes https://github.com/piotr-rojek/devopsifyme-sbemulator/issues/21