### PR TITLE
MacOS Support -- Generalized platform tag

### DIFF
--- a/src/ServiceBusEmulator.Host/Dockerfile
+++ b/src/ServiceBusEmulator.Host/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 alpine/openssl:latest AS server-cert
+FROM alpine/openssl:latest AS server-cert
 
     WORKDIR /home/testca
     COPY ./docker/rabbitmq-amqp1/testca .
@@ -14,7 +14,7 @@ FROM --platform=amd64 alpine/openssl:latest AS server-cert
         openssl ca -config openssl.cnf -in req.pem -out cert.pem -notext -batch -extensions server_ca_extensions && \
         openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:password
 
-FROM --platform=amd64 mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 
     WORKDIR /app
     COPY . ./


### PR DESCRIPTION
Removing the hardcoded platform tag, so that Docker can determine which platform to use automatically